### PR TITLE
Fix fill() in day17.js

### DIFF
--- a/src/2018/day17.js
+++ b/src/2018/day17.js
@@ -43,10 +43,10 @@ function drop(pit, x, y) {
 }
 
 function fill(pit, base) {
-  let count,
+  let count = {dry: -1, wet: -1},
     newCount = { wet: 0, dry: 0 };
-  while (count !== newCount.wet + newCount.dry) {
-    count = newCount.wet + newCount.dry;
+  while (count.dry !== newCount.dry || count.wet !== newCount.wet) {
+    count = {...newCount};
     pit.forEach(
       (line, i) =>
         (pit[i] = line


### PR DESCRIPTION
Your solution didn't work for me, because I had one case where the only change done by `drop()` was to replace `~` to `|` in one hold, and the `dry + wet` sum didn't change, so `fill()` returned, before finishing all possible watering.
With this change, it worked OK.